### PR TITLE
fix fs.unlink missing callback parameter (nodejs >= 10.0)

### DIFF
--- a/README.org
+++ b/README.org
@@ -6,6 +6,7 @@
 * Table of Contents                                                :TOC_2_gh:
 - [[#installation][Installation]]
 - [[#modify-by-mephistommm][Modify By MephistoMMM]]
+  - [[#notes][notes]]
 - [[#options][Options]]
   - [[#for-highlightjs-user][For highlight.js user]]
   - [[#for-htmlize-user][For htmlize user]]
@@ -27,7 +28,7 @@
   Switch to your hexo blog directory and run:
 
   #+BEGIN_SRC sh
-    npm install https://github.com/mephis/hexo-renderer-org#master --save
+    npm install https://github.com/mpwang/hexo-renderer-org#master --save
   #+END_SRC
 
   Then restart your hexo server.
@@ -40,6 +41,19 @@ Now, hexo-renderer-org won't start a new emacs server process in daemonize mode.
      org:
        server_file: "~/.emacs.d/server/server"  # <----- this is default value
 #+END_SRC
+
+** notes
+For MacOS user, you may need to check $TMPDIR
+#+begin_src sh
+echo $TMPDIR
+/var/folders/q0/3jxnq5cj6dz7j8szf1h5hjsc0000gn/T/
+#+end_src
+
+and set server_file to something like:
+#+begin_src yaml
+    org:
+      server_file: "/var/folders/q0/3jxnq5cj6dz7j8szf1h5hjsc0000gn/T/emacs501/server"
+#+end_src
 
 * Options
 

--- a/README.org
+++ b/README.org
@@ -230,7 +230,7 @@ Then add following to =.dir-locals.el= at the top of your hexo project:
                           (file-name-nondirectory
                            (car (url-path-and-query
                                  (url-generic-parse-url link)))))
-                         (dirname (file-name-sans-extension (buffer-name)) ))
+                         (dirname (file-name-sans-extension buffer-file-name) ))
                      ;; if directory not exist, create it
                      (unless (file-exists-p dirname)
                        (make-directory dirname))

--- a/README.org
+++ b/README.org
@@ -27,7 +27,7 @@
   Switch to your hexo blog directory and run:
 
   #+BEGIN_SRC sh
-    npm install https://github.com/mephis/hexo-renderer-org#master --save
+    npm install https://github.com/MephistoMMM/hexo-renderer-org#mephis --save
   #+END_SRC
 
   Then restart your hexo server.

--- a/README.org
+++ b/README.org
@@ -34,7 +34,7 @@
 
 * Modify By MephistoMMM
 
-Now, hexo-renderer-org won't start a new emacs server process in daemonize mode. It will use the activing one by connecting the exist emacs server socket file. You can use this codes to config the adress of emacs server socket file.
+Now, hexo-renderer-org won't start a new emacs server process in daemonize mode. It will use the activing one by connecting the exist emacs server socket file. You can use this codes to config the address of emacs server socket file.
 
 #+BEGIN_SRC yaml
      org:

--- a/emacs/hexo-renderer-org.el
+++ b/emacs/hexo-renderer-org.el
@@ -218,7 +218,9 @@ ARGS:
       ;; Write contents to output-file
       (write-region (point-min) (point-max) output-file)
       ;; bye-bye tmp buffer
-      (kill-buffer))))
+      (kill-buffer))
+    (delete-window)
+    ))
 
 
 ;; User config and other stuffs

--- a/emacs/hexo-renderer-org.el
+++ b/emacs/hexo-renderer-org.el
@@ -36,7 +36,10 @@
 ;; Disable "VC" (emacs internal version control stuff)
 (setq vc-handled-backends nil)
 
-(unless (boundp 'hexo-renderer-org--loaded)
+(unless (boundp 'hexo-renderer-org-debug)
+  (defvar hexo-renderer-org-debug nil))
+
+(unless (and (boundp 'hexo-renderer-org--loaded) (not hexo-renderer-org-debug))
 
   ;;;; Public variables
 
@@ -87,6 +90,13 @@
         (write-region (point-min) (point-max) hexo-renderer-org--debug-file))
       ;; bye-bye emacs
       (kill-emacs)))
+
+  (defun hexo-org-renderer-debug-toggle()
+    "Toggle debug to relaod hexo-renderer-org.el files."
+    (interactive)
+    (if hexo-renderer-org-debug
+        (setq hexo-renderer-org-debug nil)
+      (setq hexo-renderer-org-debug t)))
 
   ;; ;; The emacs daemon SHOULD die when error occurs.
   ;; (run-with-idle-timer

--- a/emacs/hexo-renderer-org.el
+++ b/emacs/hexo-renderer-org.el
@@ -40,7 +40,7 @@
   (defvar hexo-renderer-org-debug nil))
 
 (unless (and (boundp 'hexo-renderer-org--loaded) (not hexo-renderer-org-debug))
-
+
   ;;;; Public variables
 
   (defvar hexo-renderer-org-cachedir "./hexo-org-cache"
@@ -58,7 +58,7 @@
   (defvar hexo-renderer-org-htmlize "false"
     "Enable use Emacs's htmlize package to renderer code block or not.")
 
-
+
   ;;;; Private variables
 
   ;; for backward compability
@@ -76,7 +76,7 @@
     "YOU SHOULD NOT SETUP THIS VARIABLE.
   This variable is keeped incase org-hexo not loaded.")
 
-
+
   ;;;; Debugger
 
   (defun hexo-org-renderer-oops (msg)
@@ -112,7 +112,7 @@
   ;;           (hexo-org-renderer-oops (buffer-string))))
   ;;       ))
 
-
+
   ;;;; Initial emacs packages
 
   (when hexo-renderer-org-daemonize
@@ -125,9 +125,9 @@
 
     ;; Extra package repos
     (add-to-list 'package-archives
-                '("melpa" . "https://melpa.org/packages/") t)
+                 '("melpa" . "https://melpa.org/packages/") t)
     (add-to-list 'package-archives
-                '("org" . "http://orgmode.org/elpa/") t)
+                 '("org" . "http://orgmode.org/elpa/") t)
 
     ;; For important compatibility libraries like cl-lib
     (when (< emacs-major-version 24)
@@ -153,7 +153,7 @@
         (require 'htmlize)))
     )
 
-
+
   ;;;; Initial org-mode and ox-hexo.el
 
   (require 'org)
@@ -184,7 +184,7 @@
   (add-to-list 'load-path hexo-renderer-org--load-path)
   (autoload 'org-hexo-export-as-html "ox-hexo")
 
-
+
   ;; The exporter function
 
   (defun hexo-renderer-org-exporter ()
@@ -229,14 +229,15 @@
         ;; Write contents to output-file
         (write-region (point-min) (point-max) output-file)
         ;; bye-bye tmp buffer
-        (kill-buffer))))
+        (kill-buffer))
+      (delete-window)))
 
-
+
   ;; User config and other stuffs
 
   ;; Load user-config
   (when (and (not (string-equal hexo-renderer-org-user-config ""))
-            (file-exists-p hexo-renderer-org-user-config))
+             (file-exists-p hexo-renderer-org-user-config))
     (load-file hexo-renderer-org-user-config))
 
   ;; Load theme if specify

--- a/index.js
+++ b/index.js
@@ -34,7 +34,10 @@ hexo.on('ready', function() {
         let fullname = path.join(dir, filename);
         let stats = fs.statSync(fullname);
         if (!stats.isDirectory())
-          fs.unlink(fullname);
+          fs.unlink(fullname, (err) => {
+            if (err) throw err;
+            console.log(fullname + " was deleted");
+          });
       });
     }
   }

--- a/lib/batchStation.js
+++ b/lib/batchStation.js
@@ -1,0 +1,171 @@
+let child_process = require("child_process");
+let fs = require("fs")
+let EventEmitter = require('events');
+
+const RUNNING = symbol("running");
+const STOPED = symbol("stoped");
+
+class Operater extends EventEmitter {
+  constructor() {}
+}
+
+class Report {
+  constructor(task, tryTimes, costTime, result) {
+    this.task = task
+    this.tryTimes = tryTimes;
+    this.costTime = costTime;
+    this.result = result;
+  }
+
+  get tryTimes() {
+    return this.tryTimes;
+  }
+
+  get costTime() {
+    return this.costTime;
+  }
+
+  get result() {
+    return this.result;
+  }
+}
+
+class Task  {
+  constructor(operater, command, outfile) {
+    this.operater = operater;
+    this.command = command;
+    this.outfile = outfile;
+    this.tryTimes = 0;
+    this.startTime = new Date();
+    this.endTime = null;
+  }
+
+  get operater() {
+    return this.operater;
+  }
+
+  get command() {
+    return this.command;
+  }
+
+  get outfile() {
+    return this.outfile;
+  }
+
+  get startTime() {
+    return this.startTime;
+  }
+
+  get endTime  () {
+    return this.endTime;
+  }
+
+  AddTimes() {
+    this.tryTimes++;
+  }
+
+  Finish() {
+    this.endTime = new Date();
+  }
+
+  Report(result) {
+    return new Report(this, this.tryTimes, this.endTime - this.startTime, result);
+  }
+}
+
+
+class BatchStation {
+
+  constructor(funcCommand) {
+    this.taskList = new Array();
+    this.status = STOPED;
+    this.funcCommand = funcCommand;
+    this.engine = null;
+  }
+
+  // TODO:
+  //      - [ ] add comments
+  //      - [ ] add these codes to emacs_client
+  OperatedBy(operater, command, outfile) {
+    if (this.status === STOPED) {
+      this.StartStation();
+    }
+
+    this.taskList.push(new Task(operater, command, outfile));
+  }
+
+  StartStation() {
+    this.engine = () => {
+      this.loop();
+      setTimeout(this.engine, 10);
+    }
+
+    this.engine();
+    this.status = RUNNING;
+  }
+
+  StopStation() {
+    clearTimeout(this.engine);
+    this.status = STOPED;
+  }
+
+  hexoRenderByEmacsClient(task) {
+    return new Promise((resolve, reject) => {
+      let proc = child_process.spawn(this.funcCommand, task.command);
+
+      proc.on("exit", (code , signal) => {
+        if (code !== 0) {
+          reject(`Error: process return with code ${code}`);
+        }
+
+        resolve();
+      })
+
+
+      proc.stdout.on("data", data => {
+        if (config.org.debug) console.log("Stdout: ", data);
+      });
+      proc.stderr.on("data", data => {
+        if (config.org.debug) console.log("Stderr: ", data);
+      });
+
+      proc.on("error", (err) => {
+        reject(err);
+      });
+    });
+  }
+
+  readRenderResultFromFile(task) {
+    return new Promise((resolve, reject) => {
+      fs.readFile(task.outfile, (err, data) => {
+        if (err) reject(err);
+        resolve(task.Report(data));
+      });
+    })
+  }
+
+  emitRenderResultReport(report) {
+    report.task.operater.emit("finish", report);
+  }
+
+  loop() {
+    if (this.taskList.length <= 0) {
+      return;
+    }
+
+    let task = this.taskList.shift();
+
+    this.hexoRenderByEmacsClient(task)
+      .then(filename => {
+        loop();
+        return readRenderResultFromFile(task);
+      })
+      .then(emitRenderResultReport)
+      .catch( err => {
+        if (config.org.debug) console.error(err);
+        task.AddTimes();
+        this.taskList.unshift(task);
+        loop();
+      })
+  }
+}

--- a/lib/batchStation.js
+++ b/lib/batchStation.js
@@ -2,11 +2,15 @@ let child_process = require("child_process");
 let fs = require("fs")
 let EventEmitter = require('events');
 
-const RUNNING = symbol("running");
-const STOPED = symbol("stoped");
+const RUNNING = Symbol("running");
+const BUSY = Symbol("BUSY");
+const STOPED = Symbol("stoped");
 
-class Operater extends EventEmitter {
-  constructor() {}
+class Operator extends EventEmitter {
+  constructor(id) {
+    super();
+    this.id = id;
+  }
 }
 
 class Report {
@@ -17,22 +21,14 @@ class Report {
     this.result = result;
   }
 
-  get tryTimes() {
-    return this.tryTimes;
-  }
-
-  get costTime() {
-    return this.costTime;
-  }
-
-  get result() {
-    return this.result;
+  Show() {
+    console.log('Report: ', this.task.operator.id, this.tryTimes, this.costTime);
   }
 }
 
 class Task  {
-  constructor(operater, command, outfile) {
-    this.operater = operater;
+  constructor(operator, command, outfile) {
+    this.operator = operator;
     this.command = command;
     this.outfile = outfile;
     this.tryTimes = 0;
@@ -40,24 +36,8 @@ class Task  {
     this.endTime = null;
   }
 
-  get operater() {
-    return this.operater;
-  }
-
-  get command() {
-    return this.command;
-  }
-
-  get outfile() {
-    return this.outfile;
-  }
-
-  get startTime() {
-    return this.startTime;
-  }
-
-  get endTime  () {
-    return this.endTime;
+  Show() {
+    console.log(this.operator.id, this.command, this.outfile);
   }
 
   AddTimes() {
@@ -76,41 +56,51 @@ class Task  {
 
 class BatchStation {
 
-  constructor(funcCommand) {
+  constructor(funcCommand, debug) {
     this.taskList = new Array();
     this.status = STOPED;
     this.funcCommand = funcCommand;
     this.engine = null;
+    this.debug = debug
+
+    // private
+    this.lastFinishTime = new Date();
   }
 
   // TODO:
   //      - [ ] add comments
   //      - [ ] add these codes to emacs_client
-  OperatedBy(operater, command, outfile) {
+  OperatedBy(operator, command, outfile) {
     if (this.status === STOPED) {
       this.StartStation();
     }
 
-    this.taskList.push(new Task(operater, command, outfile));
+    this.taskList.push(new Task(operator, command, outfile));
   }
 
   StartStation() {
+    this.status = RUNNING;
     this.engine = () => {
+      if(this.status === STOPED) return;
+
       this.loop();
       setTimeout(this.engine, 10);
     }
 
     this.engine();
-    this.status = RUNNING;
+    console.log('BatchStation started.')
   }
 
   StopStation() {
     clearTimeout(this.engine);
     this.status = STOPED;
+    console.log('BatchStation stoped.')
   }
 
   hexoRenderByEmacsClient(task) {
     return new Promise((resolve, reject) => {
+      this.status = BUSY;
+      task.Show();
       let proc = child_process.spawn(this.funcCommand, task.command);
 
       proc.on("exit", (code , signal) => {
@@ -123,10 +113,10 @@ class BatchStation {
 
 
       proc.stdout.on("data", data => {
-        if (config.org.debug) console.log("Stdout: ", data);
+        if (this.debug) console.log("Stdout: ", data.toString());
       });
       proc.stderr.on("data", data => {
-        if (config.org.debug) console.log("Stderr: ", data);
+        if (this.debug) console.log("Stderr: ", data.toString());
       });
 
       proc.on("error", (err) => {
@@ -139,17 +129,26 @@ class BatchStation {
     return new Promise((resolve, reject) => {
       fs.readFile(task.outfile, (err, data) => {
         if (err) reject(err);
+        task.Finish();
         resolve(task.Report(data));
       });
     })
   }
 
   emitRenderResultReport(report) {
-    report.task.operater.emit("finish", report);
+    report.task.operator.emit("finish", report);
   }
 
   loop() {
+    if (this.status === BUSY) {
+      return;
+    }
     if (this.taskList.length <= 0) {
+      // close batchStation if idle time is longer than 2 ms
+      let now = new Date();
+      if (now - this.lastFinishTime > 2000) {
+        this.StopStation();
+      }
       return;
     }
 
@@ -157,15 +156,27 @@ class BatchStation {
 
     this.hexoRenderByEmacsClient(task)
       .then(filename => {
-        loop();
-        return readRenderResultFromFile(task);
+        this.status = RUNNING;
+        this.lastFinishTime = new Date();
+        this.loop();
+        return this.readRenderResultFromFile(task);
       })
-      .then(emitRenderResultReport)
+      .then(this.emitRenderResultReport)
       .catch( err => {
-        if (config.org.debug) console.error(err);
+        if (this.debug) console.error(err);
+        this.status = RUNNING;
         task.AddTimes();
         this.taskList.unshift(task);
-        loop();
+        this.loop();
       })
   }
 }
+
+module.exports = {
+  RUNNING,
+  STOPED,
+  Operator,
+  Report,
+  Task,
+  BatchStation
+};

--- a/lib/emacs.js
+++ b/lib/emacs.js
@@ -142,6 +142,9 @@ function emacs_client(hexo, data) {
   console.log("emacs client")
   let config = hexo.config;
 
+  batch_station = new BatchStation(config.org.emacsclient, config.org.debug);
+  batch_station.StartStation();
+
   config.highlight = config.highlight || {};
   let emacs_path = config.org.emacs;
   let output_file = tmp.fileSync();

--- a/lib/emacs.js
+++ b/lib/emacs.js
@@ -137,7 +137,6 @@ function emacs_server_load_config(hexo) {
   })
 }
 
-
 function emacs_client(hexo, data) {
   console.log("emacs client")
   let config = hexo.config;
@@ -180,12 +179,10 @@ function emacs_client(hexo, data) {
 
   return new Promise((resolve, reject) => {
     operation.attempt(currentAttempt => {
-      let proc = child_process.spawn(config.org.emacsclient, exec_args, {
-        stdio: 'inherit'
-      });
+      let proc = child_process.spawn(config.org.emacsclient, exec_args);
 
       let retryOrExit = err => {
-        if (currentAttempt > 100) return reject("Convert Error: emacs client try too many times.")
+        if (currentAttempt > 100) return reject(`Convert Error: emacs client try too many times for \n\t ${data.path}`)
         if (config.org.debug)
           console.log(`RETRY(${currentAttempt}): `, data.path);
 
@@ -203,6 +200,13 @@ function emacs_client(hexo, data) {
       proc.on('exit', (code, signal) => {
         retryOrExit(code !== 0);
       });
+
+      proc.stdout.on('data', data => {
+        if (config.org.debug) console.log("Stdout: ", data)
+      })
+      proc.stderr.on('data', data => {
+        if (config.org.debug) console.log("Stderr: ", data)
+      })
 
       proc.on('error', (err) => {
         retryOrExit(err);

--- a/lib/emacs.js
+++ b/lib/emacs.js
@@ -1,11 +1,10 @@
-'use strict';
-
 let child_process = require('child_process');
 let slash = require('slash');
 let fs = require('fs-extra');
 let tmp = require('tmp');
 let path = require('path');
 let retry = require('retry');
+let {Operator, STOPED, BatchStation} = require('./batchStation');
 
 // A variable to save current config.org.emacsclient info
 let emacsclient = "emacsclient";
@@ -18,6 +17,8 @@ let emacs_server_status = EMACS_SERVER_OFF;
 
 // Emacs daemon server-file (full path)
 let server_file = "~/.emacs.d/server/server";
+
+let batch_station = null;
 
 function fix_filepath(s) {
   if (s.length <= 0) return s;
@@ -141,6 +142,12 @@ function emacs_client(hexo, data) {
   console.log("emacs client")
   let config = hexo.config;
 
+  if(batch_station === null ) {
+    // start batch station if it null
+    batch_station = new BatchStation(config.org.emacsclient, config.org.debug);
+    batch_station.StartStation();
+  }
+
   config.highlight = config.highlight || {};
   let emacs_path = config.org.emacs;
   let output_file = tmp.fileSync();
@@ -166,52 +173,17 @@ function emacs_client(hexo, data) {
 
   let exec_args = ['-s', socket_file, '-e', emacs_lisp];
 
+  let hexo_operator = new Operator(path.basename(data.path));
+  batch_station.OperatedBy(hexo_operator, exec_args, output_file.name);
+
   // if (config.org.export_cfg != '')
   //    exec_args.splice(1,0,'--execute', config.org.export_cfg);
 
-  let operation = retry.operation({
-    retries: 100,
-    factor: 2,
-    minTimeout: 100,
-    maxTimeout: 1000,
-    randomize: true
-  });
-
   return new Promise((resolve, reject) => {
-    operation.attempt(currentAttempt => {
-      let proc = child_process.spawn(config.org.emacsclient, exec_args);
-
-      let retryOrExit = err => {
-        if (currentAttempt > 100) return reject(`Convert Error: emacs client try too many times for \n\t ${data.path}`)
-        if (config.org.debug)
-          console.log(`RETRY(${currentAttempt}): `, data.path);
-
-        const retrying = operation.retry(err);
-        if (!retrying) {
-
-          if (config.org.debug)
-            console.log("DONE: ", data.path);
-
-          let result = fs.readFileSync(output_file.name, 'utf8');
-          resolve(result); // return callback
-        }
-      }
-
-      proc.on('exit', (code, signal) => {
-        retryOrExit(code !== 0);
-      });
-
-      proc.stdout.on('data', data => {
-        if (config.org.debug) console.log("Stdout: ", data)
-      })
-      proc.stderr.on('data', data => {
-        if (config.org.debug) console.log("Stderr: ", data)
-      })
-
-      proc.on('error', (err) => {
-        retryOrExit(err);
-      });
-    });
+    hexo_operator.on('finish', report => {
+      report.Show();
+      resolve(report.result);
+    })
   })
 }
 

--- a/lib/emacs.js
+++ b/lib/emacs.js
@@ -142,11 +142,8 @@ function emacs_client(hexo, data) {
   console.log("emacs client")
   let config = hexo.config;
 
-  if(batch_station === null ) {
-    // start batch station if it null
-    batch_station = new BatchStation(config.org.emacsclient, config.org.debug);
-    batch_station.StartStation();
-  }
+  batch_station = new BatchStation(config.org.emacsclient, config.org.debug);
+  batch_station.StartStation();
 
   config.highlight = config.highlight || {};
   let emacs_path = config.org.emacs;


### PR DESCRIPTION
[fs.unlink](https://nodejs.org/api/fs.html#fs_fs_unlink_path_callback) 

v10.0.0 | The callback parameter is no longer optional. Not passing it will throw a TypeError at runtime.

which cause `hexo clean` throw exception


