### PR TITLE
Multiple enhancements

### DIFF
--- a/README.org
+++ b/README.org
@@ -216,7 +216,7 @@ Then add following to =.dir-locals.el= at the top of your hexo project:
                           (file-name-nondirectory
                            (car (url-path-and-query
                                  (url-generic-parse-url link)))))
-                         (dirname (file-name-sans-extension (buffer-name)) ))
+                         (dirname (file-name-sans-extension buffer-file-name) ))
                      ;; if directory not exist, create it
                      (unless (file-exists-p dirname)
                        (make-directory dirname))

--- a/emacs/hexo-renderer-org.el
+++ b/emacs/hexo-renderer-org.el
@@ -40,7 +40,7 @@
   (defvar hexo-renderer-org-debug nil))
 
 (unless (and (boundp 'hexo-renderer-org--loaded) (not hexo-renderer-org-debug))
-
+
   ;;;; Public variables
 
   (defvar hexo-renderer-org-cachedir "./hexo-org-cache"
@@ -58,7 +58,7 @@
   (defvar hexo-renderer-org-htmlize "false"
     "Enable use Emacs's htmlize package to renderer code block or not.")
 
-
+
   ;;;; Private variables
 
   ;; for backward compability
@@ -76,7 +76,7 @@
     "YOU SHOULD NOT SETUP THIS VARIABLE.
   This variable is keeped incase org-hexo not loaded.")
 
-
+
   ;;;; Debugger
 
   (defun hexo-org-renderer-oops (msg)
@@ -112,7 +112,7 @@
   ;;           (hexo-org-renderer-oops (buffer-string))))
   ;;       ))
 
-
+
   ;;;; Initial emacs packages
 
   (when hexo-renderer-org-daemonize
@@ -125,9 +125,9 @@
 
     ;; Extra package repos
     (add-to-list 'package-archives
-                '("melpa" . "https://melpa.org/packages/") t)
+                 '("melpa" . "https://melpa.org/packages/") t)
     (add-to-list 'package-archives
-                '("org" . "http://orgmode.org/elpa/") t)
+                 '("org" . "http://orgmode.org/elpa/") t)
 
     ;; For important compatibility libraries like cl-lib
     (when (< emacs-major-version 24)
@@ -153,7 +153,7 @@
         (require 'htmlize)))
     )
 
-
+
   ;;;; Initial org-mode and ox-hexo.el
 
   (require 'org)
@@ -184,7 +184,7 @@
   (add-to-list 'load-path hexo-renderer-org--load-path)
   (autoload 'org-hexo-export-as-html "ox-hexo")
 
-
+
   ;; The exporter function
 
   (defun hexo-renderer-org-exporter ()
@@ -229,14 +229,15 @@
         ;; Write contents to output-file
         (write-region (point-min) (point-max) output-file)
         ;; bye-bye tmp buffer
-        (kill-buffer))))
+        (kill-buffer))
+      (delete-window)))
 
-
+
   ;; User config and other stuffs
 
   ;; Load user-config
   (when (and (not (string-equal hexo-renderer-org-user-config ""))
-            (file-exists-p hexo-renderer-org-user-config))
+             (file-exists-p hexo-renderer-org-user-config))
     (load-file hexo-renderer-org-user-config))
 
   ;; Load theme if specify

--- a/index.js
+++ b/index.js
@@ -34,7 +34,10 @@ hexo.on('ready', function() {
         let fullname = path.join(dir, filename);
         let stats = fs.statSync(fullname);
         if (!stats.isDirectory())
-          fs.unlink(fullname);
+          fs.unlink(fullname, (err) => {
+            if (err) throw err;
+            console.log(fullname + " was deleted");
+          });
       });
     }
   }

--- a/lib/emacs.js
+++ b/lib/emacs.js
@@ -143,6 +143,7 @@ function emacs_client(hexo, data) {
   let config = hexo.config;
 
   if(batch_station === null || batch_station.status === STOPED) {
+    // start batch station if it null
     batch_station = new BatchStation(config.org.emacsclient, config.org.debug);
     batch_station.StartStation();
   }

--- a/lib/emacs.js
+++ b/lib/emacs.js
@@ -142,8 +142,10 @@ function emacs_client(hexo, data) {
   console.log("emacs client")
   let config = hexo.config;
 
-  batch_station = new BatchStation(config.org.emacsclient, config.org.debug);
-  batch_station.StartStation();
+  if(batch_station === null || batch_station.status === STOPED) {
+    batch_station = new BatchStation(config.org.emacsclient, config.org.debug);
+    batch_station.StartStation();
+  }
 
   config.highlight = config.highlight || {};
   let emacs_path = config.org.emacs;

--- a/lib/emacs.js
+++ b/lib/emacs.js
@@ -142,11 +142,8 @@ function emacs_client(hexo, data) {
   console.log("emacs client")
   let config = hexo.config;
 
-  if(batch_station === null ) {
-    // start batch station if it null
-    batch_station = new BatchStation(config.org.emacsclient, config.org.debug);
-    batch_station.StartStation();
-  }
+  batch_station = new BatchStation(config.org.emacsclient, config.org.debug);
+  batch_station.StartStation();
 
   config.highlight = config.highlight || {};
   let emacs_path = config.org.emacs;


### PR DESCRIPTION
# [ fs.unlink](https://nodejs.org/api/fs.html#fs_fs_unlink_path_callback)
v10.0.0 | The callback parameter is no longer optional. Not passing it will throw a TypeError at runtime.

which cause `hexo clean` throw exception

# start new batch station for every operation. 

current checking of  if batch station state is stopped is broken.

# every time emacsclient eval elisp causes emacs server GUI frame to split window on current buffer

add `(delete-window)` on elisp which emacsclient evals to avoid this behavior

# use buffer-name-file instead of buffer-name for drag&drop org-download

emacs 26.1 Org-mode 9.2

find out `(buffer-name)` return the top-level org title name instead of current file name, `buffer-name-file` gives the correct result

